### PR TITLE
v0.2.1をリリース

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 ﻿{
   "name": "jp.ootr.image-gimmicks-pack",
   "displayName": "Image Gimmicks Pack",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "unity": "2022.3",
   "description": "Image tablet gimmick for VRChat",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "jp.ootr.image-tab": "~0.2.0",
     "jp.ootr.image-screen": "~0.2.0",
     "jp.ootr.image-slide": "~0.2.0",
-    "jp.ootr.image-device-controller-visualizer": "~0.0.1"
+    "jp.ootr.image-device-controller-visualizer": "~0.0.2"
   },
   "legacyFolders": {
     "Assets\\jp.ootr\\imagetab": "44c35e5266e08d948a1cfe3898d9a753"


### PR DESCRIPTION
- 依存関係を更新
  - jp.ootr.image-device-controller-visualizer: v0.0.2